### PR TITLE
Fix small visual bug when there is only one language

### DIFF
--- a/index.js
+++ b/index.js
@@ -154,8 +154,8 @@ panel.plugin('junohamburg/language-selector', {
         },
 
         template: `
-          <div>
-            <div v-if="languages.length > 1" class="k-languages-dropdown">
+          <div v-if="languages.length > 1">
+            <div class="k-languages-dropdown">
               <k-button
                 :dropdown="true"
                 :text="code"


### PR DESCRIPTION
Fixes a small visual bug (extra space because of empty `div`) when there was only one language.

Before:
![before](https://github.com/junohamburg/kirby-language-selector/assets/41913452/45fee48c-017a-48bf-9695-a00cc6f46c0e)

After:
![after](https://github.com/junohamburg/kirby-language-selector/assets/41913452/aa02755a-a176-468a-b073-7a16e26b2897)
